### PR TITLE
Debug <think> pattern prompt and env reward settings

### DIFF
--- a/config/_8_tictactoe.yaml
+++ b/config/_8_tictactoe.yaml
@@ -7,7 +7,7 @@ trainer:
 
 actor_rollout_ref:
   rollout:
-    max_model_len: 6000  # 会超出默认的最大长度3600
+    max_model_len: 3600  # 会超出默认的最大长度3600
 
 es_manager:
   train:

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -112,7 +112,7 @@ agent_proxy:
     grouping: "state" # state / batch / inductive
     method: "identity" # asym_clip / identity / mean_std
 
-es_manager:
+es_manager:  # 数值沿用原始设定，并没有缩小规模
   format_penalty: -0.1
   train:
     env_groups: 8 # 8

--- a/config/envs.yaml
+++ b/config/envs.yaml
@@ -16,11 +16,11 @@ custom_envs:
   TicTacToe:
     env_type: tictactoe
     max_actions_per_traj: 5
-    env_instruction: "You are playing TicTacToe."
+    env_instruction: "##Game Rules: TicTacToe\n**Objective**: Be the first player to connect 3 of your pieces in a continuous line.\n**Player Pieces**:\n- Player 1: 'O'\n- Player 2: 'X'\n- Empty Slot: '.'\n**How to Play**:\n1. The game is played on a 3x3 vertical grid.\n2. Players take turns dropping one of their pieces into any available column from the top.\n3. The piece falls to the lowest unoccupied slot in that column.\n**Winning Conditions**:\nThe game ends when a player forms a line of 3 of their own pieces. The line can be:\n1.  **Horizontal** (side-by-side in a row)\n    *Example of a horizontal win for Player 1 ('O'):*\n    ```\n    X . . \n    O O O   <-- 3 'O's in row 2\n    . X . \n    ```\n2.  **Vertical** (stacked on top of each other in a column)\n    *Example of a vertical win for Player 2 ('X'):*\n    ```\n    . X O \n    O X O   <-- 3 'X's in column 2\n    . X . \n    ```\n3.  **Diagonal** (connected at an angle)\n    *Example of a diagonal win (bottom-left to top-right) for Player 1:*\n    ```\n    . . O \n    . O X   <-- 3 'O's in a diagonal line\n    O X . \n    ```\n    *Example of another diagonal win (top-left to bottom-right) for Player 2:*\n    ```\n    X . O \n    . X O   <-- 3 'X's in a diagonal line\n    . O X \n    ``` \n3.  **Diagonal** (connected at an angle)\n    *Example of a diagonal win (bottom-left to top-right) for Player 1:*\n    ```\n    . . O \n    . O X   <-- 3 'O's in a diagonal line\n    O X . \n    ```\n    *Example of another diagonal win (top-left to bottom-right) for Player 2:*\n    ```\n    X . O \n    . X O   <-- 3 'X's in a diagonal line\n    . O X \n    ```\n**Draw Condition**:\nIf the entire grid is filled with pieces and no player has won, the game is a draw."
     max_tokens: 200 # used to curate llm prompt "max words", not used for rollout
     env_config:  # 这里可以指定env_config中的config文件信息 先默认是和本地QWEN8B对战，后续看怎么改self-play
       player_info: 
-        - model_name: 'deepseek'
+        - model_name: 'google/gemini-2.5-flash'  # 换成flash，质量更高
         # - model_name: 'Qwen3-8B-Base'
         #   port: 3833
       temperature: 0.5

--- a/ragen/env/base.py
+++ b/ragen/env/base.py
@@ -269,7 +269,7 @@ class EnvPlayer():
             model=model,
             messages=message0,
             temperature=self.temperature,
-            max_tokens=1000,
+            max_tokens=200,
         )
         return response.choices[0].message.content
 

--- a/ragen/env/tictactoe/config.py
+++ b/ragen/env/tictactoe/config.py
@@ -21,7 +21,7 @@ class TicTacToeEnvConfig:
     # TODO：后续需要修改，看看self-play需要如何设置
     player_info: List[Dict[str, Any]] = field(
         # default_factory=lambda: [{'model_name': 'deepseek'}]
-        default_factory=lambda: [{'model_name': "google/gemini-2.5-flash-lite"}]
+        default_factory=lambda: [{'model_name': "google/gemini-2.5-flash"}]
         # default_factory=lambda: [{'model_name': 'tictactoe/grpo/game_40', 'port': '4040'}]
         # default_factory=lambda: [{'model_name': 'Qwen2.5-1.5B-Instruct', 'port': '2515'}]
     )

--- a/ragen/llm_agent/agent_proxy.py
+++ b/ragen/llm_agent/agent_proxy.py
@@ -147,7 +147,8 @@ class LLMAgentProxy:
 
 		for i in range(self.config.agent_proxy.max_turn):
 			lm_inputs: DataProto = ctx_manager.get_lm_inputs(env_outputs, prepare_for_update=False)
-			lm_inputs.meta_info = dataproto.meta_info # TODO: setup vllm early stop when max length is reached. make sure this can be done
+			lm_inputs.meta_info = dataproto.meta_info 
+			# TODO: setup vllm early stop when max length is reached. make sure this can be done
 			lm_outputs: DataProto = self.generate_sequences(lm_inputs)
 			# parse llm outputs -- so no need to parse action in the env
 			env_inputs: List[Dict] = ctx_manager.get_env_inputs(lm_outputs)
@@ -155,15 +156,10 @@ class LLMAgentProxy:
 			env_outputs: List[Dict] = es_manager.step(env_inputs)
 			if len(env_outputs) == 0: # all finished
 				break
-		# 像是前面记录了训练的信息，最后在这里融合一下的结果
+		# 打包所有环境的最终结果
 		rollout_states = es_manager.get_rollout_states() 
-		print('****************************************')
-		print(rollout_states[0])
-		print('****************************************')
-		print('\nstates formulate\n')
+		# 前面记录了训练的信息，最后在这里打包历史结果
 		rollouts = ctx_manager.formulate_rollouts(rollout_states)
-		print(rollouts[0])
-		# self.tokenizer.batch_decode(rollouts.batch['input_ids'], skip_special_tokens=False) # see all the trajectories
 		return rollouts
 
 @hydra.main(version_base=None, config_path="../../config", config_name="base")

--- a/ragen/trainer/agent_trainer.py
+++ b/ragen/trainer/agent_trainer.py
@@ -463,7 +463,9 @@ class RayAgentTrainer(VerlRayPPOTrainer):
             """filter rollout based on in-group max - in-group mean. We want those groups to have high-quality rollouts that deviates significantly from the mean"""
             rollout_filter_ratio = self.config.actor_rollout_ref.rollout.rollout_filter_ratio
             num_groups, group_size = self.config.es_manager.train.env_groups, self.config.es_manager.train.group_size
-
+            # original_rm_scores remove first token
+            # 在没有step_wise的reward时候，first token的score肯定是0
+            # 在这里直接 .sum(dim=-1)了，貌似并没有影响
             rm_scores = batch.batch["original_rm_scores"].sum(dim=-1).view(num_groups, group_size)
             in_group_std = rm_scores.std(dim=-1)
             in_group_max = rm_scores.max(dim=-1).values
@@ -512,6 +514,7 @@ class RayAgentTrainer(VerlRayPPOTrainer):
             with _timer("step", timing_raw):
                 # generate a batch
                 with _timer("gen", timing_raw):
+                    # rollout得到数据，filter_rollout进行轨迹过滤
                     batch = self.agent_proxy.rollout(batch, val=False)
                     batch, metrics = _filter_rollout(batch)
                     metrics.update({"train/" + key: value for key, value in batch.meta_info["metrics"].items()})
@@ -558,21 +561,24 @@ class RayAgentTrainer(VerlRayPPOTrainer):
                     self._balance_batch(batch, metrics=metrics)
 
                 # compute global_valid tokens
+                # attention_mask就是每个token都为1的tensor，加一起就是token数量
                 batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
 
-                if self.use_rm:
+                if self.use_rm:  # 为False
                     with _timer("reward", timing_raw):
                     # compute reward model score
-                        reward_tensor = self.rm_wg.compute_rm_score(batch)
+                        reward_tensor = self.rm_wg.compute_rm_score(batch)  # 这个过程会用到Attention_mask等mask信息
                         batch = batch.union(reward_tensor)
 
                 if self.config.reward_model.launch_reward_fn_async:
                     future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
                 else:
+                    # 这个地方因为没有设置，会有一个warning，不影响模型结果
                     reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 
                 # recompute old_log_probs
                 with _timer("old_log_prob", timing_raw):
+                    # 这个地方涉及到策略更新，会用到多个mask的信息
                     old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                     batch = batch.union(old_log_prob)
                     avg_old_log_prob = masked_mean(old_log_prob.batch["old_log_probs"], batch.batch["response_mask"])

--- a/ragen/workers/actor/dp_actor.py
+++ b/ragen/workers/actor/dp_actor.py
@@ -67,6 +67,7 @@ class DataParallelPPOActor(BasePPOActor):
             entropy: # (bs, response_len)
             log_probs: # (bs, response_len)
         """
+        # 'responses' mask remove the first token
         response_length = micro_batch["responses"].size(-1)
         multi_modal_inputs = {}
         if "multi_modal_inputs" in micro_batch:
@@ -82,7 +83,7 @@ class DataParallelPPOActor(BasePPOActor):
             if position_ids.dim() == 3:  # qwen2vl mrope
                 position_ids = position_ids.transpose(0, 1)  # (bsz, 3, seqlen) -> (3, bsz, seqlen)
 
-            if self.use_remove_padding:
+            if self.use_remove_padding:  # False
                 input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
                 input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
 
@@ -199,7 +200,7 @@ class DataParallelPPOActor(BasePPOActor):
 
         micro_batch_size = data.meta_info["micro_batch_size"]
         temperature = data.meta_info["temperature"]  # temperature must be in the data.meta_info to avoid silent error
-        use_dynamic_bsz = data.meta_info["use_dynamic_bsz"]
+        use_dynamic_bsz = data.meta_info["use_dynamic_bsz"]  # False
 
         select_keys = ["responses", "input_ids", "attention_mask", "position_ids"]
         batch = data.select(batch_keys=select_keys).batch
@@ -217,6 +218,7 @@ class DataParallelPPOActor(BasePPOActor):
             micro_batches = batch.split(micro_batch_size)
 
         is_peft_model = not no_lora and isinstance(self.actor_module._fsdp_wrapped_module, PeftModel)
+        # False，没有这个打印信息
         if is_peft_model:
             print(f"[INFO] Actor is a PeftModel")
             with FSDP.summon_full_params(self.actor_module):

--- a/tictactoe_gemini.sh
+++ b/tictactoe_gemini.sh
@@ -5,7 +5,7 @@ USE_GRPO="algorithm.adv_estimator=grpo agent_proxy.reward_normalization.method=m
 USE_PPO="algorithm.adv_estimator=gae" # by default.
 USE_BASE="algorithm.kl_ctrl.kl_coef=0.001 actor_rollout_ref.actor.kl_loss_coef=0.001 actor_rollout_ref.actor.clip_ratio_high=0.2 actor_rollout_ref.rollout.rollout_filter_ratio=1"
 
-LOCAL_PATH="/root/autodl-tmp/"
+LOCAL_PATH="/root/autodl-tmp/tictactoe-gemini"
 LOG_DIR="/root/RAGEN/logs/tictactoe-gemini"
 mkdir -p "$LOG_DIR" # 如果目录不存在，则创建它
 
@@ -13,11 +13,11 @@ mkdir -p "$LOG_DIR" # 如果目录不存在，则创建它
 TIMESTAMP=$(date +"%m-%d-%H-%M")
 
 # WANDB_MODE=offline python train.py --config-name _1_bandit system.CUDA_VISIBLE_DEVICES=\"0,4\" trainer.n_gpus_per_node=2 actor_rollout_ref.rollout.tensor_model_parallel_size=2 trainer.experiment_name=bandit-ppo $USE_PPO &
-WANDB_MODE=offline python train.py --config-name _8_tictactoe \
+WANDB_MODE=offline RAY_DEDUP_LOGS=0 python train.py --config-name _8_tictactoe \
  system.CUDA_VISIBLE_DEVICES=\"0,1\" \
- model_path=/root/autodl-tmp/Qwen3-1.7B \
+ model_path=/root/autodl-tmp/Qwen2.5-1.5B-Instruct \
  trainer.default_local_dir=$LOCAL_PATH \
- trainer.total_training_steps=80 \
+ trainer.total_training_steps=100 \
  trainer.n_gpus_per_node=2 \
  actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
  trainer.experiment_name=tictactoe-gemini-grpo \


### PR DESCRIPTION
Find thousands of bugs and fix them...

In training process:
* Every prompt is formulated by chat-template and add a <think> token to forbid the model thinking. However, this process is impossible in evaluating the model's ability. So we remove this pattern. 
* Every prompt is concatenated with the env_prompt before. The message looks like: `env_instruction` + `prompt for turn 1` + `answer for turn 1` + `reward for turn 1` + `prompt for turn 2` ... In the previous setting, we set rule description in prompt for each turn, which causes lots of redundant prompt. We move this information into `env_instruction` to make prompt simple.

In environment settings: 
* Original game rewards are between 0 - 1, but the initial TicTacToe rewards are between -1 - 1. Update reward settings.
* Aligning with the `format_penalty` setting, invalid actions (actions that are not in the `available_action_list`) are set reward -0.1 and ask the model to try again.