### PR TITLE
Add mix

### DIFF
--- a/config/_10_math.yaml
+++ b/config/_10_math.yaml
@@ -3,11 +3,11 @@ defaults:
 
 trainer:
   experiment_name: Math
-  save_freq: 20
+  save_freq: 50
 
 actor_rollout_ref:
   rollout:
-    max_model_len: 3600 
+    max_model_len: 6000 
 es_manager:  # 数值沿用原始设定，并没有缩小规模
   format_penalty: -0.1
   train:
@@ -24,3 +24,5 @@ es_manager:  # 数值沿用原始设定，并没有缩小规模
       tags: ["MathTest"]
       n_groups: [32] # [256] -> [32] # TODO: If not set, all env names divide nums equally. Under the same group, the env config and env seed (prompt) are equal in each generation
 
+agent_proxy:
+  max_turn: 1  # 数学题不需要反复问，直接终止就行——这个会影响到数学+game的联合训练？

--- a/config/_11_mix.yaml
+++ b/config/_11_mix.yaml
@@ -1,0 +1,28 @@
+defaults:
+  - base
+
+trainer:
+  experiment_name: Mix
+  save_freq: 50
+
+actor_rollout_ref:
+  rollout:
+    max_model_len: 6000 
+es_manager:  # 数值沿用原始设定，并没有缩小规模
+  format_penalty: -0.1
+  train:
+    env_groups: 16 # 8 + 2
+    # under the same group, the env config and env seed are ensured to be equal
+    group_size: 16  # 16
+    env_configs:
+      tags: ["MixTrain"]
+      n_groups: [16] # If not set, all env names divide nums equally. Under the same group, the env config and env seed (prompt) are equal in each generation
+  val:
+    env_groups: 32 # 256 -> 32
+    group_size: 1 # should be set to 1 because when val temperature is set to 0 and group size > 1, there will be repetitive prompts which leads to same trajectory.
+    env_configs:
+      tags: ["MixTest"]
+      n_groups: [32] # [256] -> [32] # TODO: If not set, all env names divide nums equally. Under the same group, the env config and env seed (prompt) are equal in each generation
+
+agent_proxy:
+  max_turn: 1  # 数学题不需要反复问，直接终止就行——这个会影响到数学+game的联合训练？

--- a/config/_8_tictactoe.yaml
+++ b/config/_8_tictactoe.yaml
@@ -3,7 +3,7 @@ defaults:
 
 trainer:
   experiment_name: TicTacToe
-  save_freq: 20
+  save_freq: 50
 
 actor_rollout_ref:
   rollout:
@@ -11,8 +11,12 @@ actor_rollout_ref:
 
 es_manager:
   train:
+    env_groups: 16 # 多开几个，保证多样性
+    # under the same group, the env config and env seed are ensured to be equal
+    group_size: 16  # 16
     env_configs:
       tags: ["TicTacToe"]
+      n_groups: [16]
   val:
     env_configs:
       tags: ["TicTacToe"]

--- a/config/envs.yaml
+++ b/config/envs.yaml
@@ -46,6 +46,25 @@ custom_envs:
       data_files: "SimpleRL-Zoo-Data/simplelr_abel_level3to5"
       mode: "test"
     
+  MixTrain:
+    env_type: mix_data
+    max_actions_per_traj: 1 # used in environment state manager to control the actual max actions executed per trajectory
+    env_instruction: ""
+    max_tokens: 200 # used to curate llm prompt "max words", not used for rollout
+    env_config: # keys should be a subset of MathConfig
+      data_path: "/root/autodl-tmp"  # "/data1/lvnuoyan"
+      data_files: "merge_mmlu_math"
+      mode: "train"
+  MixTest:
+    env_type: mix_data
+    max_actions_per_traj: 1 # used in environment state manager to control the actual max actions executed per trajectory
+    env_instruction: ""
+    max_tokens: 200 # used to curate llm prompt "max words", not used for rollout
+    env_config: # keys should be a subset of MathConfig
+      data_path: "/root/autodl-tmp"  # "/data1/lvnuoyan"
+      data_files: "merge_mmlu_math"
+      mode: "test"
+  
 
   SimpleSokoban:
     env_type: sokoban

--- a/math.sh
+++ b/math.sh
@@ -5,20 +5,20 @@ USE_GRPO="algorithm.adv_estimator=grpo agent_proxy.reward_normalization.method=m
 USE_PPO="algorithm.adv_estimator=gae" # by default.
 USE_BASE="algorithm.kl_ctrl.kl_coef=0.001 actor_rollout_ref.actor.kl_loss_coef=0.001 actor_rollout_ref.actor.clip_ratio_high=0.2 actor_rollout_ref.rollout.rollout_filter_ratio=1"
 
-LOCAL_PATH="/root/autodl-tmp/tictactoe-math"
-LOG_DIR="/root/RAGEN/logs/tictactoe-math"
+LOCAL_PATH="/root/autodl-tmp/math"
+LOG_DIR="/root/RAGEN/logs/math"
 mkdir -p "$LOG_DIR" # 如果目录不存在，则创建它
 
 # 获取当前时间，格式为 YYYY-MM-DD-HHMMSS
 TIMESTAMP=$(date +"%m-%d-%H-%M")
 
-WANDB_MODE=offline RAY_DEDUP_LOGS=0 python train.py --config-name _9_tictactoe_math \
+WANDB_MODE=offline RAY_DEDUP_LOGS=0 python train.py --config-name _10_math \
  system.CUDA_VISIBLE_DEVICES=\"0,1\" \
  model_path=/root/autodl-tmp/Qwen2.5-1.5B-Instruct \
  trainer.default_local_dir=$LOCAL_PATH \
- trainer.total_training_steps=150 \
+ trainer.total_training_steps=200 \
  trainer.n_gpus_per_node=2 \
  actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
- trainer.experiment_name=tictactoe-gemini-math \
+ trainer.experiment_name=math \
  $USE_GRPO 2>&1 | tee "$LOG_DIR/grpo_${TIMESTAMP}.log" &
 # WANDB_MODE=offline python train.py --config-name _2_sokoban system.CUDA_VISIBLE_DEVICES=\"3,4\" trainer.n_gpus_per_node=2 actor_rollout_ref.rollout.tensor_model_parallel_size=2 trainer.experiment_name=sokoban-grpo actor_rollout_ref.rollout.rollout_filter_ratio=0.25 $USE_GRPO &

--- a/merge.sh
+++ b/merge.sh
@@ -1,5 +1,5 @@
-ORI_PATH="/root/autodl-tmp/math/global_step_200/actor"
-TAR_PATH="/root/autodl-tmp/math/math200"
+ORI_PATH="/root/autodl-tmp/tictactoe-math/global_step_60/actor"
+TAR_PATH="/root/autodl-tmp/tictactoe-math/game60"
 HF_PATH="/root/autodl-tmp/Qwen2.5-1.5B-Instruct"
 
 python verl/scripts/model_merger.py --backend fsdp --local_dir $ORI_PATH --target_dir $TAR_PATH --hf_model_path $HF_PATH

--- a/merge.sh
+++ b/merge.sh
@@ -1,5 +1,5 @@
-ORI_PATH="/root/autodl-tmp/tictactoe-gemini-think/global_step_300/actor"
-TAR_PATH="/root/autodl-tmp/tictactoe-gemini-think/game300"
+ORI_PATH="/root/autodl-tmp/math/global_step_200/actor"
+TAR_PATH="/root/autodl-tmp/math/math200"
 HF_PATH="/root/autodl-tmp/Qwen2.5-1.5B-Instruct"
 
 python verl/scripts/model_merger.py --backend fsdp --local_dir $ORI_PATH --target_dir $TAR_PATH --hf_model_path $HF_PATH

--- a/merge_dl.sh
+++ b/merge_dl.sh
@@ -2,9 +2,9 @@
 
 # --- 用户配置部分 ---
 # 模型检查点所在的根目录
-ROOT_DIR="/root/autodl-tmp/tictactoe-gemini-think"
+ROOT_DIR="/root/autodl-tmp/tictactoe-math"
 # 合并后模型保存的根目录
-TAR_ROOT_DIR="/root/autodl-tmp/tictactoe-gemini-think"
+TAR_ROOT_DIR="/root/autodl-tmp/tictactoe-math"
 # Hugging Face 模型的路径
 HF_PATH="/root/autodl-tmp/Qwen2.5-1.5B-Instruct"
 # --- 用户配置部分结束 ---

--- a/ragen/env/__init__.py
+++ b/ragen/env/__init__.py
@@ -16,6 +16,8 @@ from .tictactoe.env import TicTacToeEnv
 from .tictactoe.config import TicTacToeEnvConfig
 from .math_lv3to5.env import MathEnv
 from .math_lv3to5.config import MathEnvConfig
+from .mix_data.env import MixEnv
+from .mix_data.config import MixEnvConfig
 
 
 REGISTERED_ENVS = {
@@ -28,6 +30,7 @@ REGISTERED_ENVS = {
     'connect4': Connect4Env,
     'tictactoe': TicTacToeEnv,
     'math_lv3to5': MathEnv,
+    'mix_data': MixEnv,
 }
 
 REGISTERED_ENV_CONFIGS = {
@@ -40,6 +43,7 @@ REGISTERED_ENV_CONFIGS = {
     'connect4': Connect4EnvConfig,
     'tictactoe': TicTacToeEnvConfig,
     'math_lv3to5': MathEnvConfig,
+    'mix_data': MixEnvConfig,
 }
 
 try:

--- a/ragen/env/mix_data/__init__.py
+++ b/ragen/env/mix_data/__init__.py
@@ -1,0 +1,4 @@
+from .env import MixEnv
+from .config import MixEnvConfig
+
+__all__ = ["MixEnv", "MixEnvConfig"]

--- a/ragen/env/mix_data/config.py
+++ b/ragen/env/mix_data/config.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Any
+
+@dataclass
+class MixEnvConfig:
+    render_mode: str = "text"
+    data_path: str = "/root/autodl-tmp"  # "/data1/lvnuoyan"
+    seed: int = 123
+    mode: str = "test"
+    # 数据文件设置，小模型使用abel、大模型使用qwen
+    data_files: str = "merge_mmlu_math"

--- a/ragen/env/mix_data/gen_data.py
+++ b/ragen/env/mix_data/gen_data.py
@@ -1,0 +1,105 @@
+from datasets import load_dataset
+import random
+import pandas as pd
+import os
+
+# 固定随机种子
+seed = 42
+random.seed(seed)
+
+root_path = '/root/autodl-tmp/reasoning'
+dir_name = 'merge_mmlu_math'
+
+# --- MMLU 字段格式化 ---
+def format_mmlu_item(example):
+    # 格式化 question + 选项
+    formatted_question = (
+        example["question"].strip() + "\n"
+        + f"A. {example['choices'][0]}\n"
+        + f"B. {example['choices'][1]}\n"
+        + f"C. {example['choices'][2]}\n"
+        + f"D. {example['choices'][3]}\n"
+    )
+
+    # 将数字答案（0-3）转换为字母（A-D）
+    num_to_letter = {0: "A", 1: "B", 2: "C", 3: "D"}
+    formatted_answer = num_to_letter.get(example["answer"], "")
+    # 直接用原始字段不行，
+    # huggingface dataset对象是强类型的，
+    # 每个字段在 schema（即 Arrow table schema）中都有固定类型
+    # 类型相同可以覆盖，类型不同——比如这里的answer从int类型变成了str类型就无法覆盖
+    # 新命名一个字段
+    return {
+        "formatted_question": formatted_question,
+        "formatted_answer": formatted_answer
+    }
+
+
+# 加载 MMLU 数据集，全部数据集all、对应训练数据字段auxiliary_train
+mmlu = load_dataset(f"{root_path}/mmlu/", 'all')['auxiliary_train']
+
+# 加载 Math 数据集
+math = load_dataset("parquet", 
+                    data_files=f"{root_path}/SimpleRL-Zoo-Data/simplelr_abel_level3to5/train.parquet")['train']
+
+# 随机抽取各 1000 条
+mmlu_sample = mmlu.shuffle(seed=seed).select(range(1000))
+math_sample = math.shuffle(seed=seed).select(range(1000))
+
+# 随机抽取test数据各100条
+test_mmlu = load_dataset(f"{root_path}/mmlu/", 'all')['test'].shuffle(seed=seed).select(range(100))
+test_math = load_dataset("parquet", 
+                    data_files=f"{root_path}/SimpleRL-Zoo-Data/simplelr_abel_level3to5/test.parquet")['train'].shuffle(seed=seed).select(range(100))
+
+# 字段统一
+# MMLU：格式化
+# 对 mmlu_sample 应用格式化函数
+mmlu_formatted = mmlu_sample.map(format_mmlu_item)
+# 转换为 DataFrame
+mmlu_df = pd.DataFrame({
+    "question": mmlu_formatted["formatted_question"],
+    "answer": mmlu_formatted["formatted_answer"],
+    "type": "mmlu"
+})
+
+mmlu_test_form = test_mmlu.map(format_mmlu_item)
+mmlu_test_df = pd.DataFrame({
+    "question": mmlu_test_form["formatted_question"],
+    "answer": mmlu_test_form["formatted_answer"],
+    "type": "mmlu"
+})
+
+# Math：字段在 extra_info 中
+math_df = pd.DataFrame({
+    "question": [x["question"] for x in math_sample["extra_info"]],
+    "answer": [x["answer"] for x in math_sample["extra_info"]],
+    "type": "math"
+})
+
+math_test_df = pd.DataFrame({
+    "question": [x["question"] for x in test_math["extra_info"]],
+    "answer": [x["answer"] for x in test_math["extra_info"]],
+    "type": "math"
+})
+
+# 合并——这里不太需要打乱顺序，后续的训练也会抽取一部分打乱
+merged_df = pd.concat([mmlu_df, math_df], ignore_index=True)
+
+merged_test = pd.concat([mmlu_test_df, math_test_df], ignore_index=True)
+
+# 如果文件夹不存在则创建
+os.makedirs(f"{root_path}/{dir_name}", exist_ok=True)
+
+# 保存为train.parquet文件
+output_path = f"{root_path}/{dir_name}/train.parquet"
+merged_df.to_parquet(output_path, index=False)
+# 保存对应的test文件
+output_test_path = f"{root_path}/{dir_name}/test.parquet"
+merged_test.to_parquet(output_test_path, index=False)
+
+
+
+print(f"已成功生成合并后的train文件：{output_path}")
+print(merged_df.head())
+print(f"已成功生成合并后的test文件：{output_test_path}")
+print(merged_test.head())

--- a/ragen/env/nashenv/__init__.py
+++ b/ragen/env/nashenv/__init__.py
@@ -1,0 +1,4 @@
+from .env import NashEnv
+from .config import NashEnvConfig
+
+__all__ = ["NashEnv", "NashEnvConfig"]

--- a/ragen/env/nashenv/config.py
+++ b/ragen/env/nashenv/config.py
@@ -1,0 +1,41 @@
+# nashenv/config.py
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+@dataclass
+class NashEnvConfig:
+    game: str = "PD"
+    custom_matrices: Optional[Tuple[Tuple[Tuple[int,int],Tuple[int,int]],
+                                    Tuple[Tuple[int,int],Tuple[int,int]]]] = None
+    action_labels_p1: Tuple[str, str] = ("A", "B")
+    action_labels_p2: Tuple[str, str] = ("X", "Y")
+    force_role: Optional[str] = None
+    mode: str = "pure_nash_member"  
+    seed: int = 123 
+
+    def get_payoff_matrices(self):
+        if self.custom_matrices is not None:
+            return self.custom_matrices[0], self.custom_matrices[1]
+
+        if self.game.upper() == "PD":
+            A = ((3, 0),
+                 (5, 1))  # P1 payoff
+            B = ((3, 5),
+                 (0, 1))  # P2 payoff
+            return A, B
+
+        if self.game.upper() == "SH":
+            A = ((4, 0),
+                 (3, 3))
+            B = ((4, 3),
+                 (0, 3))
+            return A, B
+
+        if self.game.upper() == "MP":
+            A = ((1, -1),
+                 (-1, 1))
+            B = ((-1, 1),
+                 (1, -1))
+            return A, B
+
+        raise ValueError(f"Unknown game type: {self.game}")

--- a/ragen/env/nashenv/env.py
+++ b/ragen/env/nashenv/env.py
@@ -1,0 +1,297 @@
+# nashenv/env.py
+from __future__ import annotations
+from typing import Dict, Any, Tuple, List, Optional
+import numpy as np
+import nashpy as nash  
+from .config import NashEnvConfig
+
+
+class NashEnv:
+    """
+    完全信息 2x2 矩阵博弈环境（接口与 bandit 对齐）
+      - reset(seed) -> str
+      - step(action) -> (str, reward, done, info)
+      - render() -> str
+    """
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, config: Optional[NashEnvConfig] = None):
+        self.config = config or NashEnvConfig()
+        self.np_random: Optional[np.random.RandomState] = None
+
+        # payoff matrices
+        self.A: Optional[Tuple[Tuple[int, int], Tuple[int, int]]] = None  # P1 payoff
+        self.B: Optional[Tuple[Tuple[int, int], Tuple[int, int]]] = None  # P2 payoff
+
+        # runtime state
+        self.role: str = "P1"
+        self.variant_idx: int = 0
+        self.last_prompt: str = ""
+        self._done: bool = False
+        self.valid_actions: List[int] = [1, 2]
+        self.templates = self._build_templates()
+        self.seed = self.config.seed
+
+        self.reset(self.seed)
+
+    #bandit接口 
+    def reset(self, seed: Optional[int] = None) -> str:
+        if seed is not None:
+            self.np_random = np.random.RandomState(seed)
+        elif self.np_random is None:
+            self.np_random = np.random.RandomState(0)
+        self._done = False
+
+        # payoff matrices 来自 config
+        self.A, self.B = self.config.get_payoff_matrices()
+
+        self.variant_idx = int(self.np_random.randint(0, len(self.templates)))
+        if self.config.force_role in ("P1", "P2"):
+            self.role = self.config.force_role
+        else:
+            self.role = "P1" if int(self.np_random.randint(0, 2)) == 0 else "P2"
+        self.last_prompt = self._render_prompt()
+        return self.last_prompt
+
+    def step(self, action: str) -> Tuple[str, int, bool, Dict[str, Any]]:
+        """根据 nashpy计算NE给reward"""
+        if self._done:
+            info = dict(
+                action_is_valid=False,
+                action_is_effective=False,
+                success=False,
+                reason="episode_already_done",
+            )
+            return self.last_prompt, 0, True, info
+        try:
+            action = int(action)
+            is_valid = action in self.valid_actions
+        except:
+            is_valid = False
+        if not is_valid:
+            info = dict(
+                action_is_valid=False,
+                action_is_effective=False,
+                success=False,
+                reason="invalid_action",
+            )
+            self._done = True
+            return self.last_prompt, 0, True, info
+        game = nash.Game(np.array(self.A), np.array(self.B))
+        NE = self._pure_nash_equilibria()  # [(row, col), ...]
+
+        idx = action - 1
+        success = False
+        if self.role == "P1":
+            success = any(r == idx for (r, c) in NE)
+        else:  # P2
+            success = any(c == idx for (r, c) in NE)
+
+        reward = 1 if success else 0
+
+        self._done = True
+
+        info: Dict[str, Any] = {
+            "action_is_valid": True,
+            "action_is_effective": success,
+            "success": success,
+            "role": self.role,
+            "NE": [(int(r), int(c)) for (r, c) in NE],
+        }
+        return self.last_prompt, reward, True, info
+
+    def render(self) -> str:
+        return self.last_prompt
+
+    def close(self):
+        pass
+
+    #内部函数
+    #版本问题，手写用is_best_response 代替game.pure_nash_equilibria()判断纯策略纳什均衡
+    def _pure_nash_equilibria(self) -> List[Tuple[int, int]]:
+        game = nash.Game(np.array(self.A), np.array(self.B))
+        NE = []
+        for i in [0, 1]:   # P1 行
+            for j in [0, 1]:  # P2 列
+                row_strategy = np.zeros(2); row_strategy[i] = 1
+                col_strategy = np.zeros(2); col_strategy[j] = 1
+                is_row_best, is_col_best = game.is_best_response(row_strategy, col_strategy)
+                if is_row_best and is_col_best:
+                    NE.append((i, j))
+        return NE
+
+    #构建prompt，12种
+    def _build_templates(self) -> List[str]:
+        templates: List[str] = []
+
+        # Markdown 双表
+        templates.append(
+            "{role}.\n\n"
+            "### P1's payoff\n"
+            "|      | {p2x} | {p2y} |\n"
+            "|------|-------|-------|\n"
+            "| {p1a} | {A11} | {A12} |\n"
+            "| {p1b} | {A21} | {A22} |\n\n"
+            "### P2's payoff\n"
+            "|      | {p2x} | {p2y} |\n"
+            "|------|-------|-------|\n"
+            "| {p1a} | {B11} | {B12} |\n"
+            "| {p1b} | {B21} | {B22} |\n\n"
+            "{instr}\n"
+        )
+
+        # 单表(P1,P2)
+        templates.append(
+            "{role}.\n\n"
+            "|      | {p2x}         | {p2y}         |\n"
+            "|------|---------------|---------------|\n"
+            "| {p1a} | ({A11},{B11}) | ({A12},{B12}) |\n"
+            "| {p1b} | ({A21},{B21}) | ({A22},{B22}) |\n\n"
+            "{instr}\n"
+        )
+
+        # 逐格文字
+        templates.append(
+            "{role}.\n\n"
+            "- If P1={p1a}, P2={p2x} → (P1:{A11}, P2:{B11})\n"
+            "- If P1={p1a}, P2={p2y} → (P1:{A12}, P2:{B12})\n"
+            "- If P1={p1b}, P2={p2x} → (P1:{A21}, P2:{B21})\n"
+            "- If P1={p1b}, P2={p2y} → (P1:{A22}, P2:{B22})\n\n"
+            "{instr}\n"
+        )
+
+        # 数组
+        templates.append(
+            "{role}.\n\n"
+            "P1 payoff = [[{A11},{A12}],[{A21},{A22}]]\n"
+            "P2 payoff = [[{B11},{B12}],[{B21},{B22}]]\n\n"
+            "{instr}\n"
+        )
+
+        # 对话体
+        templates.append(
+            "{role}.\n\n"
+            "You (P1) vs Opponent (P2).\n"
+            "P1 payoff: [[{A11},{A12}],[{A21},{A22}]]\n"
+            "P2 payoff: [[{B11},{B12}],[{B21},{B22}]]\n\n"
+            "{instr}\n"
+        )
+
+        # Alice/Bob
+        templates.append(
+            "{role}.\n\n"
+            "Alice (P1) and Bob (P2) play a game.\n"
+            "|      | {p2x}         | {p2y}         |\n"
+            "|------|---------------|---------------|\n"
+            "| {p1a} | ({A11},{B11}) | ({A12},{B12}) |\n"
+            "| {p1b} | ({A21},{B21}) | ({A22},{B22}) |\n\n"
+            "{instr}\n"
+        )
+
+        # 公司竞争
+        templates.append(
+            "{role}.\n\n"
+            "Company A (P1) and Company B (P2).\n"
+            "- ({p1a},{p2x}) = ({A11},{B11})\n"
+            "- ({p1a},{p2y}) = ({A12},{B12})\n"
+            "- ({p1b},{p2x}) = ({A21},{B21})\n"
+            "- ({p1b},{p2y}) = ({A22},{B22})\n\n"
+            "{instr}\n"
+        )
+
+        # 动物狩猎
+        templates.append(
+            "{role}.\n\n"
+            "Two animals choose strategies:\n"
+            "|      | {p2x}         | {p2y}         |\n"
+            "|------|---------------|---------------|\n"
+            "| {p1a} | ({A11},{B11}) | ({A12},{B12}) |\n"
+            "| {p1b} | ({A21},{B21}) | ({A22},{B22}) |\n\n"
+            "{instr}\n"
+        )
+
+        # Q&A 
+        templates.append(
+            "{role}.\n\n"
+            "Q: What are the payoffs?\n"
+            "A: ({p1a},{p2x})=({A11},{B11}), "
+            "({p1a},{p2y})=({A12},{B12}), "
+            "({p1b},{p2x})=({A21},{B21}), "
+            "({p1b},{p2y})=({A22},{B22}).\n\n"
+            "{instr}\n"
+        )
+
+        # 分步骤
+        templates.append(
+            "{role}.\n\n"
+            "Step 1: Observe payoff matrices\n"
+            "- P1: [[{A11},{A12}],[{A21},{A22}]]\n"
+            "- P2: [[{B11},{B12}],[{B21},{B22}]]\n"
+            "Step 2: Decide.\n\n"
+            "{instr}\n"
+        )
+
+        #  极简
+        templates.append(
+            "{role}.\n\n"
+            "Game:\n"
+            "A = [[{A11},{A12}],[{A21},{A22}]]\n"
+            "B = [[{B11},{B12}],[{B21},{B22}]]\n\n"
+            "{instr}\n"
+        )
+
+        # 强调完全信息
+        templates.append(
+            "{role}.\n\n"
+            "This is a complete-information 2x2 game.\n"
+            "|      | {p2x}         | {p2y}         |\n"
+            "|------|---------------|---------------|\n"
+            "| {p1a} | ({A11},{B11}) | ({A12},{B12}) |\n"
+            "| {p1b} | ({A21},{B21}) | ({A22},{B22}) |\n\n"
+            "{instr}\n"
+        )
+
+        return templates
+
+    def _render_prompt(self) -> str:
+        p1a, p1b = self.config.action_labels_p1
+        p2x, p2y = self.config.action_labels_p2
+        A11, A12 = self.A[0]
+        A21, A22 = self.A[1]
+        B11, B12 = self.B[0]
+        B21, B22 = self.B[1]
+
+        role_sent = "You are Player 1 (P1)" if self.role == "P1" else "You are Player 2 (P2)"
+
+        instr = (
+            f"Choose your action:\n"
+            f"- Enter 1 to select {p1a if self.role=='P1' else p2x}\n"
+            f"- Enter 2 to select {p1b if self.role=='P1' else p2y}"
+        )
+
+        template = self.templates[self.variant_idx]
+        return template.format(
+            role=role_sent,
+            p1a=p1a, p1b=p1b, p2x=p2x, p2y=p2y,
+            A11=A11, A12=A12, A21=A21, A22=A22,
+            B11=B11, B12=B12, B21=B21, B22=B22,
+            instr=instr,
+        )
+
+
+# 本地演示
+if __name__ == "__main__":
+    from .config import NashEnvConfig
+    cfg = NashEnvConfig(game="PD")
+    env = NashEnv(cfg)
+
+    print("RESET (seed=42)")
+    obs = env.reset(seed=10)
+    print(obs)
+
+    print("STEP (action=2)")
+    obs2, reward, done, info = env.step('1')
+    print("reward:", reward, "done:", done)
+    print("NE:", info["NE"])
+    print("success:", info["success"])

--- a/reason_test/extract_math.py
+++ b/reason_test/extract_math.py
@@ -1,82 +1,86 @@
 # 根据infer得到的结果，运行函数提取模型生成的信息
 import json
 import re
+import time
 import datasets
 import tqdm
 from math_verify import parse, verify
+import os
 
-root_path = '/data1/lvnuoyan' # '/root/autodl-tmp'# 
-file_name = 'game100-gsm8k-09-23-17-39.json'
+
+# file_name = 'game100-gsm8k-09-23-17-39.json'
+root_path = '/root/autodl-tmp'
+file_name = 'tictactoe-math-game20-10-01-19-00.json'
 # file_name = 'Qwen2.5-1.5B-Instruct-gsm8k-09-23-17-44.json'
-
-def extract_solution(solution_str, method="strict"):
-    assert method in ["strict", "flexible"]
-    if method == "strict":
-        # this also tests the formatting of the model
-        # 更精确的正则表达式
-        pattern = r"<answer>(-?\d+\.?\d*)</answer>"
-        # 使用 re.search() 提取最后一个数字
-        match = re.search(pattern, solution_str, re.DOTALL)
-        if match:
-            last_number = match.group(1)  # 提取匹配到的最后一个数字
-            return last_number
-        else:
-            return None 
-    elif method == "flexible":
-        # 但是这个flexible匹配明明已经是宽松版本了，但还是匹配不到——可能还是训废了？        
-        answer = re.findall("(\\-?[0-9\\.\\,]+)", solution_str)
-        # print(answer)
-        final_answer = None
-        if len(answer) == 0:
-            # no reward is there is no answer
-            pass
-        else:
-            r = 1
-            invalid_str = ["", ".", ',']
-            # find the last number that is not '.'
-            for final_answer in reversed(answer):
-                if final_answer not in invalid_str:
-                    r = 0
-                    break
-            if r:
-                return None
-            # 删除多余的逗号、末尾的多余字符（可能会匹配到末尾的小数点）
-            while not final_answer[-1].isdigit():
-                final_answer = final_answer[:-1]
-            final_answer = final_answer.replace(',', '')
-    return final_answer
+# game100不使用原始prompt17-39： 0.4025, strict 0.3161
+# Game100使用原始prompt21-55：0.3321——所以改了prompt反而效果更差，，strict 0.2009
 
 
-def extract_math(method='strict'):
-    accs = []
-    answers = json.load(open(file_name))
+def extract_solution(solution_str):
+    pattern = r"<answer>(.*)</answer>"
+    # 使用 re.search() 提取最后一个数字
+    match = re.search(pattern, solution_str, re.DOTALL)
+    solu_flex = solution_str
+    if match:
+        last_number = match.group(1)  # 提取匹配到的最后一个数字
+        solu_strict = last_number
+        solu_flex = last_number
+    else:
+        solu_strict = None 
+    return solu_strict, solu_flex
+
+
+def extract_math(answers, math):
+    accs_strict = []
+    accs_flex = []
     for i in tqdm.trange(len(math['test'])):  # len(math['test'])
-        # 调整prompt内容，之前的格式不太对劲
-        a = answers[i]
-        solution = extract_solution(a, method)
-        # print(solution)
-        # print(type(ground_truth))
-        # 之前发现可能表达式不同但实际上是一个数值的情况，比如100.00和100，然后可能有多余的
-        # 先不考虑这个情况
-        ground_truth = math['test']['reward_model'][i]['ground_truth']
-        # print(solution)
-        if solution is None:
-            accs.append(None)
-        elif float(solution) == float(ground_truth):
-            accs.append(1)
+        # 调整prompt内容，之前的格式不太对劲，导致模型输出的最后一个数字不是最后一个数字
+        answer = answers[i]
+        solu_strict, solu_flex = extract_solution(answer)
+        # answers.append(outputs[0].outputs[0].text)
+        # print(outputs[0].outputs[0].text)
+        # ground_truth = parse(math[i]['extra_info']['answer'])
+        ground_truth = parse(math['test']['reward_model'][i]['ground_truth'])
+        # print(answers[0])
+        # print(solu_strict)
+        # print(solu_flex)
+        # print(ground_truth)
+        correct_strict = verify(parse(solu_strict), ground_truth)
+        if solu_strict is None:
+            accs_strict.append(None)
+        elif correct_strict:
+            accs_strict.append(1)
         else:
-            print(solution, ground_truth)
-            accs.append(0)
-    return accs, answers
+            # print(solution, ground_truth)
+            accs_strict.append(0)
+        correct_flex = verify(parse(solu_flex), ground_truth)
+        if solu_flex is None:
+            accs_flex.append(None)
+        elif correct_flex:
+            accs_flex.append(1)
+        else:
+            accs_flex.append(0)
+        # print(accs_strict[0], accs_flex[0])
+        # exit(0)
+    return accs_strict, accs_flex, answers
+
+if __name__ == '__main__':
+    path0 = f'{root_path}/reasoning'
+    math = datasets.load_dataset("parquet", 
+                  data_files={'train': path0 + '/gsm8k/train.parquet', 'test': path0 + '/gsm8k/test.parquet'})
+    # print(math['test']['prompt'][0])
+    # math = datasets.load_dataset('parquet', 
+    #                 data_files=f'{path0}/SimpleRL-Zoo-Data/simplelr_abel_level3to5/test.parquet')['train']
+    # # exit(0)
+    with open(file_name, 'r') as f:
+        answers = json.load(f)
+    accs_strict, accs_flex, answers = extract_math(answers, math)
+    acc0 = accs_strict.count(1) / len(accs_strict)
+    print('----------strict mode------------')
+    print('total acc:', acc0)
+    print('invalid output:', accs_strict.count(None))
+    print('----------flexible mode----------')
+    acc0 = accs_flex.count(1) / len(accs_flex)
+    print('total acc:', acc0)
 
 
-path0 = f'{root_path}/reasoning'
-math = datasets.load_dataset("parquet", 
-              data_files={'train': path0 + '/gsm8k/train.parquet', 'test': path0 + '/gsm8k/test.parquet'})
-# print(math['test']['prompt'][0])
-
-# exit(0)
-accs, answers = extract_math('flexible')
-acc0 = accs.count(1) / len(accs)
-print('total acc:', acc0)
-print('invalid output:', accs.count(None))

--- a/reason_test/lv3to5_dl.py
+++ b/reason_test/lv3to5_dl.py
@@ -1,4 +1,3 @@
-# 根据infer得到的结果，运行函数提取模型生成的信息
 import json
 import re
 import time
@@ -11,9 +10,10 @@ from verl.utils import hf_tokenizer
 
 root_path = '/root/autodl-tmp'  # '/data1/lvnuoyan' 
 model_path = 'tictactoe-math'
+# model_path = 'tictactoe-math'
 model_name = 'game40'
+# tokenizer = hf_tokenizer(f"{root_path}/{model_path}/{model_name}")
 tokenizer = hf_tokenizer(f"{root_path}/{model_path}/{model_name}")
-# tokenizer = hf_tokenizer(f"{root_path}/{model_name}")
 time_str = time.strftime("%m-%d-%H-%M", time.localtime())
 # file_name = 'game100-gsm8k-09-23-17-39.json'
 # file_name = 'Qwen2.5-1.5B-Instruct-gsm8k-09-23-17-44.json'
@@ -24,8 +24,8 @@ def load_llm():
     os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
     os.environ["CUDA_VISIBLE_DEVICES"] = '0'
     # tokenizer = AutoTokenizer.from_pretrained(config.actor_rollout_ref.model.path)
-    model = f'{root_path}/{model_path}/{model_name}'
-    # model = f"{root_path}/{model_name}"
+    # model = f'{root_path}/{model_path}/{model_name}'
+    model = f"{root_path}/{model_path}/{model_name}"
     # ro_config = config.actor_rollout_ref.rollout
     llm = LLM(
 		model,
@@ -43,8 +43,7 @@ def reformat_prompt(prompt0):
     # 将prompt句子末尾的 Let\'s think step by step and output the final answer after "####".
     # 替换为Let\'s think step by step and output your think and final answer in this format: 
     # <think> [your thought] </think> <answer> [your answer] </answer>
-    prompt = prompt0.replace("Let\'s think step by step and output the final answer after \"####\".", 
-                             "Let\'s think step by step and always output: <think> [Your thoughts] </think> <answer> [your answer] </answer> with no extra text. Strictly follow this format. Max response length: 200 words (tokens).")
+    prompt = prompt0 + "Let\'s think step by step and always output: <think> [Your thoughts] </think> <answer> [your answer] </answer> with no extra text. Strictly follow this format. Max response length: 200 words (tokens)."
     message = [{"role": "system", "content": "You're a helpful assistant. "},
                {"role": "user", "content": prompt}]
     # apply_chat_template
@@ -70,14 +69,14 @@ def test_math(llm, sampling_params, math):
     accs_strict = []
     accs_flex = []
     answers = []
-    for i in tqdm.trange(len(math['test'])):  # len(math['test'])
+    for i in tqdm.trange(len(math)):  # len(math['test'])
         # 调整prompt内容，之前的格式不太对劲，导致模型输出的最后一个数字不是最后一个数字
-        prompt = reformat_prompt(math['test'][i]['prompt'][0]['content'])# 模型推理
+        prompt = reformat_prompt(math[i]['extra_info']['question'])# 模型推理
         outputs = llm.generate(prompt, sampling_params)
         solu_strict, solu_flex = extract_solution(outputs[0].outputs[0].text)
         answers.append(outputs[0].outputs[0].text)
         # print(outputs[0].outputs[0].text)
-        ground_truth = parse(math['test'][i]['reward_model']['ground_truth'])
+        ground_truth = parse(math[i]['extra_info']['answer'])
         correct_strict = verify(parse(solu_strict), ground_truth)
         if solu_strict is None:
             accs_strict.append(None)
@@ -95,21 +94,26 @@ def test_math(llm, sampling_params, math):
             accs_flex.append(0)
     return accs_strict, accs_flex, answers
 
+
+# 复制出问题了，需要改回mathlv3-5的数据集
 if __name__ == '__main__':
     path0 = f'{root_path}/reasoning'
+    # math = datasets.load_dataset("parquet", 
+    #               data_files={'train': path0 + '/gsm8k/train.parquet', 'test': path0 + '/gsm8k/test.parquet'})
+    # # print(math['test']['prompt'][0])
     math = datasets.load_dataset("parquet", 
-                  data_files={'train': path0 + '/gsm8k/train.parquet', 'test': path0 + '/gsm8k/test.parquet'})
-    # print(math['test']['prompt'][0])
+                  data_files=path0 + '/SimpleRL-Zoo-Data/simplelr_abel_level3to5/test.parquet')['train']
     llm, sampling_params = load_llm()
     # exit(0)
     accs_strict, accs_flex, answers = test_math(llm, sampling_params, math)
     acc0 = accs_strict.count(1) / len(accs_strict)
-    print('-----------------strict mode-----------------')
+    print('-----------strict mode-----------')
     print('total acc:', acc0)
     print('invalid output:', accs_strict.count(None))
-    print('-----------------flexible mode-----------------')
+    print('-----------flexible mode---------')
     acc0 = accs_flex.count(1) / len(accs_flex)
     print('total acc:', acc0)
     # answers存储
-    with open(f'reason_test/gsm8k-{model_name}-{time_str}.json', 'w') as f:
+    with open(f'reason_test/lv3to5-{model_name}-{time_str}.json', 'w') as f:
         json.dump(answers, f)
+

--- a/reason_test/lv3to5_dl.py
+++ b/reason_test/lv3to5_dl.py
@@ -9,9 +9,9 @@ from vllm import LLM, SamplingParams
 from verl.utils import hf_tokenizer
 
 root_path = '/root/autodl-tmp'  # '/data1/lvnuoyan' 
+# model_path = 'math'
 model_path = 'tictactoe-math'
-# model_path = 'tictactoe-math'
-model_name = 'game40'
+model_name = 'game60'
 # tokenizer = hf_tokenizer(f"{root_path}/{model_path}/{model_name}")
 tokenizer = hf_tokenizer(f"{root_path}/{model_path}/{model_name}")
 time_str = time.strftime("%m-%d-%H-%M", time.localtime())

--- a/reason_test/math_dl.py
+++ b/reason_test/math_dl.py
@@ -11,7 +11,7 @@ from verl.utils import hf_tokenizer
 
 root_path = '/root/autodl-tmp'  # '/data1/lvnuoyan' 
 model_path = 'tictactoe-math'
-model_name = 'game40'
+model_name = 'game60'
 tokenizer = hf_tokenizer(f"{root_path}/{model_path}/{model_name}")
 # tokenizer = hf_tokenizer(f"{root_path}/{model_name}")
 time_str = time.strftime("%m-%d-%H-%M", time.localtime())
@@ -104,10 +104,10 @@ if __name__ == '__main__':
     # exit(0)
     accs_strict, accs_flex, answers = test_math(llm, sampling_params, math)
     acc0 = accs_strict.count(1) / len(accs_strict)
-    print('-----------------strict mode-----------------')
+    print('-----------strict mode-----------')
     print('total acc:', acc0)
     print('invalid output:', accs_strict.count(None))
-    print('-----------------flexible mode-----------------')
+    print('----------flexible mode----------')
     acc0 = accs_flex.count(1) / len(accs_flex)
     print('total acc:', acc0)
     # answers存储

--- a/tictactoe_gemini.sh
+++ b/tictactoe_gemini.sh
@@ -5,8 +5,8 @@ USE_GRPO="algorithm.adv_estimator=grpo agent_proxy.reward_normalization.method=m
 USE_PPO="algorithm.adv_estimator=gae" # by default.
 USE_BASE="algorithm.kl_ctrl.kl_coef=0.001 actor_rollout_ref.actor.kl_loss_coef=0.001 actor_rollout_ref.actor.clip_ratio_high=0.2 actor_rollout_ref.rollout.rollout_filter_ratio=1"
 
-LOCAL_PATH="/root/autodl-tmp/tictactoe-gemini-think"
-LOG_DIR="/root/RAGEN/logs/tictactoe-gemini-think"
+LOCAL_PATH="/root/autodl-tmp/tictactoe"
+LOG_DIR="/root/RAGEN/logs/tictactoe"
 mkdir -p "$LOG_DIR" # 如果目录不存在，则创建它
 
 # 获取当前时间，格式为 YYYY-MM-DD-HHMMSS
@@ -16,7 +16,7 @@ WANDB_MODE=offline RAY_DEDUP_LOGS=0 python train.py --config-name _8_tictactoe \
  system.CUDA_VISIBLE_DEVICES=\"0,1\" \
  model_path=/root/autodl-tmp/Qwen2.5-1.5B-Instruct \
  trainer.default_local_dir=$LOCAL_PATH \
- trainer.total_training_steps=400 \
+ trainer.total_training_steps=100 \
  trainer.n_gpus_per_node=2 \
  actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
  trainer.experiment_name=tictactoe-gemini-think \


### PR DESCRIPTION
Add mix environment. 

Mix data are composed of math_lv3to5 and mmlu datasets. 
- `train.parquet` is made up of `math_lv3to5` training data and `mmlu` all dataset 'auxiliary_train' data.
-  `test.parquet` is made up of `math_lv3to5` test data and `mmlu` all dataset `test` data.

Mix script is similar to math env.

Update math `env.py`
- Add validation check. Use math-verify `parse` function output.

Add initial nash environment.
- Prompt should be updated. 
- Not registered in config files.
